### PR TITLE
Timeout is extended for each message received

### DIFF
--- a/message/subscriber/read.go
+++ b/message/subscriber/read.go
@@ -8,6 +8,7 @@ import (
 
 // BulkRead reads provided amount of messages from the provided channel, until a timeout occurrs or the limit is reached.
 func BulkRead(messagesCh <-chan *message.Message, limit int, timeout time.Duration) (receivedMessages message.Messages, all bool) {
+	timeoutCh := time.After(timeout)
 MessagesLoop:
 	for len(receivedMessages) < limit {
 		select {
@@ -18,7 +19,7 @@ MessagesLoop:
 
 			receivedMessages = append(receivedMessages, msg)
 			msg.Ack()
-		case <-time.After(timeout):
+		case <-timeoutCh:
 			break MessagesLoop
 		}
 	}
@@ -30,7 +31,7 @@ MessagesLoop:
 // until a timeout occurrs or the limit is reached.
 func BulkReadWithDeduplication(messagesCh <-chan *message.Message, limit int, timeout time.Duration) (receivedMessages message.Messages, all bool) {
 	receivedIDs := map[string]struct{}{}
-
+	timeoutCh := time.After(timeout)
 MessagesLoop:
 	for len(receivedMessages) < limit {
 		select {
@@ -44,7 +45,7 @@ MessagesLoop:
 				receivedMessages = append(receivedMessages, msg)
 			}
 			msg.Ack()
-		case <-time.After(timeout):
+		case <-timeoutCh:
 			break MessagesLoop
 		}
 	}


### PR DESCRIPTION
This PR is mainly for discussion regarding the intended behavior.

Not sure if the intention of timeout to function as an idle timeout or a collection timeout.
It currently behaves as an idle timeout with the bound of taking up to `timeout * limit` in length if each message takes almost timeout to arrive.
Should it collect messages for up to timeout and then return?